### PR TITLE
Fix a typo in the ImageSet ref for GCP 4.10

### DIFF
--- a/ci-pools/clusterpools/gcp/canary-gcp-latest-410.clusterpool.yaml
+++ b/ci-pools/clusterpools/gcp/canary-gcp-latest-410.clusterpool.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   baseDomain: gcp.red-chesterfield.com
   imageSetRef:
-    name: openshift-v4100
+    name: openshift-v4100-rc1
   installConfigSecretTemplateRef:
     name: gcp-standard-install-config
   platform:


### PR DESCRIPTION
## Summary of Changes

Fix a typo in the imageset name for the 4.10 GCP clusterpool