### PR TITLE
Change 4.12 to leverage GA content

### DIFF
--- a/ci-pools/clusterimagesets/4.12/openshift-latest-412.clusterimageset.yaml
+++ b/ci-pools/clusterimagesets/4.12/openshift-latest-412.clusterimageset.yaml
@@ -3,4 +3,4 @@ kind: ClusterImageSet
 metadata:
   name: openshift-latest-412
 spec:
-  releaseImage: 'quay.io/openshift-release-dev/ocp-release:4.12.0-rc.8-multi'
+  releaseImage: 'quay.io/openshift-release-dev/ocp-release:4.12.0-multi'


### PR DESCRIPTION
## Summary of Changes

Changes the OpenShift 4.12 ClusterImageSet to leverage the now-GA 4.12.0 build